### PR TITLE
Add orchestrator and headless inference pipeline

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,3 +66,29 @@ To set up the project, follow these steps:
    Install with:
    ```bash
    pip install -r requirements.txt
+```
+
+## Orchestrating runs (training & inference)
+
+The new `orchestrator.py` script provides a thin automation layer for
+deepfake frame classification experiments. It reads the YAML file at
+`config/run.yaml`, spins up per-model run directories under
+`runs/{model}/{timestamp}/`, and wires environment variables so the
+existing training scripts can resume, pick seeds, and respect custom
+dataset splits.
+
+1. **Train models listed in the config** (ensure `mode: training`):
+   ```bash
+   python orchestrator.py --config config/run.yaml
+   ```
+2. **Evaluate models headlessly** (toggle `mode: inference` in the same
+   config to reuse the dataset/weights settings):
+   ```bash
+   python orchestrator.py --config config/run.yaml
+   ```
+
+Each run directory contains `checkpoints/` (latest & best checkpoints),
+`logs/` (console output plus JSONL metrics), and `plots/` (confusion
+matrix and ROC curve when labels are available). The setup targets
+frame-level deepfake vs. real classification but works for multiclass
+ImageFolder datasets as well (e.g., MNIST variants converted to RGB).

--- a/config/run.yaml
+++ b/config/run.yaml
@@ -1,0 +1,26 @@
+mode: training
+seed: 1337
+device: cuda
+
+data:
+  root: data/DeepFakeFrames
+  train_split: train
+  val_split: val
+  test_split: test
+  num_classes: 2
+  img_size: 224
+
+models:
+  - name: efficientnet_b3
+    enabled: true
+    output_dir: runs/efficientnet_b3
+    training:
+      epochs: 10
+      batch_size: 64
+      num_workers: 4
+      resume: auto
+    inference:
+      weights: weights/EfficientNet_10_21_2025.pth
+      split: test
+      batch_size: 256
+      num_workers: 2

--- a/inference_cli.py
+++ b/inference_cli.py
@@ -1,0 +1,224 @@
+"""Headless inference utility for DeepfakeDetection."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+from datetime import datetime
+from pathlib import Path
+from time import perf_counter
+from typing import Any
+
+import matplotlib.pyplot as plt
+import torch
+import yaml
+from rich.console import Console
+from rich.progress import (
+    BarColumn,
+    MofNCompleteColumn,
+    Progress,
+    TextColumn,
+    TimeElapsedColumn,
+    TimeRemainingColumn,
+)
+from sklearn.metrics import ConfusionMatrixDisplay, confusion_matrix, roc_auc_score
+from torch.utils.data import DataLoader
+from torchvision import datasets
+
+from pipeline import DeepfakePipeline
+
+console = Console()
+
+def load_config(path: Path) -> dict[str, Any]:
+    with path.open("r", encoding="utf-8") as handle:
+        return yaml.safe_load(handle)
+
+
+def build_dataloader(
+    dataset: datasets.ImageFolder,
+    batch_size: int,
+    num_workers: int,
+) -> DataLoader:
+    kwargs: dict[str, Any] = {
+        "batch_size": batch_size,
+        "shuffle": False,
+        "num_workers": num_workers,
+        "pin_memory": True,
+        "persistent_workers": num_workers > 0,
+    }
+    if num_workers > 0:
+        kwargs["prefetch_factor"] = 2
+    return DataLoader(dataset, **kwargs)
+
+
+def save_confusion_matrix(cm: torch.Tensor, labels: list[str], path: Path) -> None:
+    disp = ConfusionMatrixDisplay(confusion_matrix=cm.numpy(), display_labels=labels)
+    fig, ax = plt.subplots(figsize=(6, 5))
+    disp.plot(ax=ax, cmap="Blues", colorbar=False)
+    fig.tight_layout()
+    fig.savefig(path)
+    plt.close(fig)
+
+
+def save_roc_curve(y_true: torch.Tensor, y_scores: torch.Tensor, path: Path) -> None:
+    from sklearn.metrics import RocCurveDisplay
+
+    fig, ax = plt.subplots(figsize=(6, 5))
+    RocCurveDisplay.from_predictions(y_true.numpy(), y_scores.numpy(), ax=ax)
+    ax.set_title("ROC Curve")
+    fig.tight_layout()
+    fig.savefig(path)
+    plt.close(fig)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Run batched inference on an ImageFolder split.")
+    parser.add_argument("--config", default="config/run.yaml", type=Path)
+    parser.add_argument("--model-name", required=True)
+    parser.add_argument("--run-dir", type=Path)
+    args = parser.parse_args()
+
+    config = load_config(args.config)
+    model_cfg = next((m for m in config.get("models", []) if m.get("name") == args.model_name), None)
+    if model_cfg is None:
+        console.print(f"[bold red]Model {args.model_name} not found in config[/]")
+        raise SystemExit(1)
+
+    data_cfg = config.get("data", {})
+    inference_cfg = model_cfg.get("inference", {})
+
+    base_output = Path(model_cfg.get("output_dir", f"runs/{args.model_name}"))
+    timestamp = datetime.now().strftime("%Y%m%d-%H%M%S")
+    run_dir = args.run_dir or (base_output / timestamp)
+    run_dir = run_dir.resolve()
+    logs_dir = run_dir / "logs"
+    plots_dir = run_dir / "plots"
+    for path in (run_dir, logs_dir, plots_dir):
+        path.mkdir(parents=True, exist_ok=True)
+
+    weights_path = inference_cfg.get("weights")
+    if weights_path is not None:
+        weights_path = Path(weights_path)
+        if not weights_path.is_absolute():
+            weights_path = (args.config.parent / weights_path).resolve()
+    else:
+        weights_path = None
+
+    device_str = os.environ.get("DD_DEVICE", config.get("device", "cuda"))
+    if device_str.startswith("cuda") and not torch.cuda.is_available():
+        console.print("[bold yellow]⚠️  CUDA requested but unavailable[/]: using CPU")
+        device_str = "cpu"
+    device = torch.device(device_str)
+
+    pipeline = DeepfakePipeline(device=device)
+    num_classes = int(model_cfg.get("num_classes", data_cfg.get("num_classes", 2)))
+    pipeline.load_model(args.model_name, num_classes, weights_path)
+    transforms = pipeline.build_transforms(
+        image_size=inference_cfg.get("img_size", data_cfg.get("img_size")),
+    )
+
+    data_root_value = data_cfg.get("root", "data/DeepFakeFrames")
+    data_root = Path(data_root_value).expanduser()
+    if not data_root.is_absolute():
+        data_root = (args.config.parent / data_root).resolve()
+
+    split = inference_cfg.get("split", data_cfg.get("test_split", "test"))
+    dataset_path = data_root / split
+    if not dataset_path.exists():
+        console.print(f"[bold red]Split not found:[/] {dataset_path}")
+        raise SystemExit(1)
+
+    dataset = datasets.ImageFolder(dataset_path, transform=transforms)
+    if len(dataset) == 0:
+        console.print(f"[bold yellow]No images found in[/] {dataset_path}")
+        return
+
+    batch_size = int(inference_cfg.get("batch_size", 64))
+    num_workers = int(inference_cfg.get("num_workers", 4))
+    dataloader = build_dataloader(dataset, batch_size=batch_size, num_workers=num_workers)
+
+    progress = Progress(
+        TextColumn("[bold blue]{task.description}"),
+        BarColumn(bar_width=None),
+        MofNCompleteColumn(),
+        TimeElapsedColumn(),
+        TimeRemainingColumn(),
+        TextColumn("{task.fields[speed]}"),
+        console=console,
+    )
+
+    all_probs: list[torch.Tensor] = []
+    all_preds: list[torch.Tensor] = []
+    all_targets: list[torch.Tensor] = []
+
+    start = perf_counter()
+    images_seen = 0
+    with progress:
+        task = progress.add_task("inference", total=len(dataloader), speed="")
+        for images, targets in dataloader:
+            logits = pipeline.predict_batch(images)
+            probs, preds = pipeline.postprocess(logits)
+            all_probs.append(probs.cpu())
+            all_preds.append(preds.cpu())
+            all_targets.append(targets.cpu())
+            images_seen += targets.size(0)
+            elapsed = perf_counter() - start
+            speed = images_seen / max(elapsed, 1e-6)
+            progress.update(task, advance=1, speed=f"{speed:.1f} img/s")
+
+    probs_tensor = torch.cat(all_probs, dim=0)
+    preds_tensor = torch.cat(all_preds, dim=0)
+    targets_tensor = torch.cat(all_targets, dim=0)
+
+    accuracy = (preds_tensor == targets_tensor).float().mean().item()
+    metrics: dict[str, Any] = {
+        "model": args.model_name,
+        "split": split,
+        "accuracy": accuracy,
+        "timestamp": datetime.now().isoformat(),
+    }
+
+    unique_targets = torch.unique(targets_tensor)
+    if unique_targets.numel() > 1:
+        try:
+            if num_classes == 2:
+                roc_auc = roc_auc_score(targets_tensor.numpy(), probs_tensor[:, 1].numpy())
+            else:
+                roc_auc = roc_auc_score(
+                    targets_tensor.numpy(),
+                    probs_tensor.numpy(),
+                    multi_class="ovr",
+                )
+            metrics["roc_auc"] = float(roc_auc)
+        except ValueError:
+            pass
+
+        cm = confusion_matrix(targets_tensor.numpy(), preds_tensor.numpy())
+        cm_tensor = torch.from_numpy(cm)
+        metrics["confusion_matrix"] = cm_tensor.tolist()
+        cm_path = plots_dir / "confusion_matrix.png"
+        save_confusion_matrix(cm_tensor, dataset.classes, cm_path)
+
+        if num_classes == 2:
+            roc_path = plots_dir / "roc_curve.png"
+            save_roc_curve(targets_tensor, probs_tensor[:, 1], roc_path)
+    else:
+        cm = confusion_matrix(targets_tensor.numpy(), preds_tensor.numpy())
+        cm_tensor = torch.from_numpy(cm)
+        metrics["confusion_matrix"] = cm_tensor.tolist()
+        cm_path = plots_dir / "confusion_matrix.png"
+        save_confusion_matrix(cm_tensor, dataset.classes, cm_path)
+
+    metrics_path = logs_dir / "metrics.jsonl"
+    with metrics_path.open("a", encoding="utf-8") as handle:
+        handle.write(json.dumps(metrics) + "\n")
+
+    console.print(
+        f"[bold]Accuracy[/]: {accuracy:.4f} | "
+        + " | ".join(f"{k}={v:.4f}" for k, v in metrics.items() if isinstance(v, float) and k != "accuracy")
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/model_zoo.py
+++ b/model_zoo.py
@@ -1,0 +1,101 @@
+"""Model registry for DeepfakeDetection orchestrator.
+
+This module exposes a tiny registry so orchestration code can look up
+metadata about each backbone: where its training script lives, what input
+resolution it expects by default, and how to instantiate the architecture
+for inference. The goal is to keep the project focused on deepfake frame
+classification while making it easy to extend to new backbones.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from dataclasses import dataclass, replace
+
+import timm
+from efficientnet_pytorch import EfficientNet
+from fastervit import create_model
+from torch import nn
+
+
+@dataclass(frozen=True)
+class ModelSpec:
+    """Metadata required to orchestrate training and inference."""
+
+    name: str
+    train_script: str
+    weights_key: str
+    default_image_size: int
+    builder: Callable[[str, int], nn.Module]
+
+
+def _build_efficientnet(_: str, num_classes: int) -> nn.Module:
+    model = EfficientNet.from_name("efficientnet-b3")
+    in_features = model._fc.in_features  # type: ignore[attr-defined]
+    model._fc = nn.Linear(in_features, num_classes)  # type: ignore[attr-defined]
+    return model
+
+
+def _build_efficientformer(model_name: str, num_classes: int) -> nn.Module:
+    return timm.create_model(model_name, pretrained=False, num_classes=num_classes)
+
+
+def _build_fastervit(model_name: str, num_classes: int) -> nn.Module:
+    model = create_model(model_name, pretrained=False)
+    in_features = model.head.in_features  # type: ignore[attr-defined]
+    model.head = nn.Linear(in_features, num_classes)  # type: ignore[attr-defined]
+    return model
+
+
+_EXACT_SPECS: dict[str, ModelSpec] = {
+    "efficientnet_b3": ModelSpec(
+        name="efficientnet_b3",
+        train_script="models/efficientnet/train.py",
+        weights_key="efficientnet_b3",
+        default_image_size=224,
+        builder=_build_efficientnet,
+    ),
+}
+
+_PREFIX_SPECS: dict[str, ModelSpec] = {
+    "efficientformer": ModelSpec(
+        name="efficientformer_v2_s1",
+        train_script="models/efficientformer_v2/train.py",
+        weights_key="efficientformer_v2_s1",
+        default_image_size=224,
+        builder=_build_efficientformer,
+    ),
+    "faster_vit": ModelSpec(
+        name="faster_vit_2_224",
+        train_script="models/fastervit/train.py",
+        weights_key="faster_vit_2_224",
+        default_image_size=224,
+        builder=_build_fastervit,
+    ),
+}
+
+
+def get_model_spec(model_name: str) -> ModelSpec:
+    """Return the :class:`ModelSpec` for ``model_name``.
+
+    The registry keeps the layer thin: it knows where to find the training
+    script and how to build the architecture so we can load weights for
+    inference. It supports both exact model names (e.g., ``efficientnet_b3``)
+    and prefix matches like ``efficientformer_v2_s1`` or ``faster_vit_2_224``.
+    """
+
+    if model_name in _EXACT_SPECS:
+        return _EXACT_SPECS[model_name]
+
+    for prefix, spec in _PREFIX_SPECS.items():
+        if model_name.startswith(prefix):
+            return replace(
+                spec,
+                name=model_name,
+                weights_key=model_name,
+            )
+
+    raise KeyError(f"Unknown model '{model_name}'. Add it to model_zoo.py.")
+
+
+__all__ = ["ModelSpec", "get_model_spec"]

--- a/models/efficientformer_v2/train.py
+++ b/models/efficientformer_v2/train.py
@@ -14,9 +14,13 @@ Training regime:
 
 from __future__ import annotations
 
+import os
+import random
 from pathlib import Path
 from time import perf_counter
+from typing import Any
 
+import numpy as np
 import timm
 import torch
 from rich.console import Console
@@ -30,17 +34,20 @@ from rich.progress import (
     TimeRemainingColumn,
 )
 from torch import nn, optim
+from torch.optim.lr_scheduler import LRScheduler
 from torch.utils.data import DataLoader
 from torchvision import datasets, transforms
 
 # Configuration constants (could be moved to a config file).
-DATA_ROOT: Path = Path.home() / "code" / "DeepfakeDetection" / "data" / "Dataset"
+DEFAULT_DATA_ROOT: Path = Path.home() / "code" / "DeepfakeDetection" / "data" / "Dataset"
 MODEL_NAME: str = "efficientformerv2_s1"
 EPOCHS: int = 5
 BATCH_SIZE: int = 128
 IMG_SIZE: int = 224
 NUM_WORKERS: int = 8
-OUTPUT_WEIGHTS: Path = Path("EfficientFormerV2_S1.pth")
+DEFAULT_WEIGHTS_NAME: str = "efficientformer_v2_s1_weights.pth"
+DEFAULT_LATEST_CKPT: str = "latest.ckpt"
+DEFAULT_BEST_CKPT: str = "best.ckpt"
 
 # Parameter name substrings to unfreeze after the head-only warmup.
 UNFREEZE_KEYS: tuple[str, ...] = (
@@ -57,10 +64,58 @@ UNFREEZE_KEYS: tuple[str, ...] = (
 console = Console()
 
 
+def set_seed(seed: int) -> None:
+    """Seed Python, NumPy, and PyTorch for reproducible experiments."""
+
+    random.seed(seed)
+    np.random.seed(seed)
+    torch.manual_seed(seed)
+    torch.cuda.manual_seed_all(seed)
+    torch.backends.cudnn.deterministic = True
+    torch.backends.cudnn.benchmark = False
+
+
+def save_checkpoint(
+    path: Path,
+    *,
+    model: nn.Module,
+    optimizer: optim.Optimizer | None,
+    scheduler: LRScheduler | None,
+    epoch: int,
+    phase: str,
+    best_val_acc: float,
+    best_epoch: int,
+) -> None:
+    """Persist the training state for warm starts orchestrated externally."""
+
+    state: dict[str, Any] = {
+        "epoch": epoch,
+        "phase": phase,
+        "model": model.state_dict(),
+        "optimizer": optimizer.state_dict() if optimizer is not None else None,
+        "scheduler": scheduler.state_dict() if scheduler is not None else None,
+        "best_val_acc": best_val_acc,
+        "best_epoch": best_epoch,
+    }
+    torch.save(state, path)
+
+
+def load_checkpoint(path: Path, device: torch.device) -> dict[str, Any] | None:
+    """Load the checkpoint if present."""
+
+    if not path.exists():
+        return None
+    return torch.load(path, map_location=device)
+
+
 def get_loaders(
     data_root: Path,
     img_size: int,
     batch_size: int,
+    *,
+    train_split: str,
+    val_split: str,
+    num_workers: int,
 ) -> tuple[DataLoader, DataLoader]:
     """Build train/validation loaders with light augmentations on train."""
     train_t = transforms.Compose(
@@ -79,24 +134,32 @@ def get_loaders(
         ],
     )
 
-    train_ds = datasets.ImageFolder(data_root / "Train", transform=train_t)
-    val_ds = datasets.ImageFolder(data_root / "Validation", transform=val_t)
+    train_ds = datasets.ImageFolder(data_root / train_split, transform=train_t)
+    val_ds = datasets.ImageFolder(data_root / val_split, transform=val_t)
+
+    loader_kwargs = {
+        "num_workers": num_workers,
+        "pin_memory": True,
+        "persistent_workers": num_workers > 0,
+    }
+    if num_workers > 0:
+        loader_kwargs["prefetch_factor"] = 2
 
     train_dl = DataLoader(
         train_ds,
         batch_size=batch_size,
         shuffle=True,
-        num_workers=NUM_WORKERS,
-        pin_memory=True,
-        persistent_workers=NUM_WORKERS > 0,
+        **loader_kwargs,
     )
+    val_loader_kwargs = loader_kwargs.copy()
+    val_loader_kwargs.pop("prefetch_factor", None)
+    if num_workers > 0:
+        val_loader_kwargs["prefetch_factor"] = 2
     val_dl = DataLoader(
         val_ds,
         batch_size=batch_size,
         shuffle=False,
-        num_workers=NUM_WORKERS,
-        pin_memory=True,
-        persistent_workers=NUM_WORKERS > 0,
+        **val_loader_kwargs,
     )
     return train_dl, val_dl
 
@@ -157,44 +220,96 @@ def train_one_epoch(  # noqa: PLR0913
 
 def main() -> None:  # noqa: PLR0915
     """Entrypoint: device setup, data, warmup, fine-tune, save weights."""
-    # Device selection and basic info.
-    use_cuda = torch.cuda.is_available()
-    device = "cuda" if use_cuda else "cpu"
+
+    output_dir = Path(os.environ.get("DD_OUTPUT_DIR", ".")).expanduser().resolve()
+    checkpoints_dir = output_dir / "checkpoints"
+    logs_dir = output_dir / "logs"
+    for path in (output_dir, checkpoints_dir, logs_dir):
+        path.mkdir(parents=True, exist_ok=True)
+
+    best_weights_path = checkpoints_dir / DEFAULT_WEIGHTS_NAME
+    latest_ckpt_path = checkpoints_dir / DEFAULT_LATEST_CKPT
+    best_ckpt_path = checkpoints_dir / DEFAULT_BEST_CKPT
+
+    data_root = Path(os.environ.get("DD_DATA_ROOT", DEFAULT_DATA_ROOT)).expanduser()
+    train_split = os.environ.get("DD_TRAIN_SPLIT", "Train")
+    val_split = os.environ.get("DD_VAL_SPLIT", "Validation")
+
+    img_size = int(os.environ.get("DD_IMG_SIZE", IMG_SIZE))
+    batch_size = int(os.environ.get("DD_BATCH_SIZE", BATCH_SIZE))
+    epochs = int(os.environ.get("DD_EPOCHS", EPOCHS))
+    num_workers = int(os.environ.get("DD_NUM_WORKERS", NUM_WORKERS))
+    num_classes = int(os.environ.get("DD_NUM_CLASSES", 2))
+
+    seed_env = os.environ.get("DD_SEED")
+    seeded = False
+    if seed_env is not None:
+        try:
+            seed_value = int(seed_env)
+        except ValueError:
+            console.print(f"[bold yellow]Invalid DD_SEED[/]: {seed_env}")
+        else:
+            set_seed(seed_value)
+            seeded = True
+            console.print(f"[bold]Seeded[/]: {seed_value}")
+
+    device_env = os.environ.get("DD_DEVICE")
+    if device_env:
+        device = device_env
+        use_cuda = device.startswith("cuda") and torch.cuda.is_available()
+        if device.startswith("cuda") and not torch.cuda.is_available():
+            console.print(
+                "[bold yellow]⚠️  Requested CUDA device unavailable[/]: falling back to CPU",
+            )
+            device = "cpu"
+            use_cuda = False
+    else:
+        use_cuda = torch.cuda.is_available()
+        device = "cuda" if use_cuda else "cpu"
+
     if use_cuda:
+        if not seeded:
+            torch.backends.cudnn.benchmark = True
         console.print("[bold green]✅ CUDA available[/]: using GPU")
         console.print(f"Device: {torch.cuda.get_device_name(0)}")
     else:
         console.print("[bold yellow]⚠️  CUDA not available[/]: falling back to CPU")
 
-    # Dataset presence check (ImageFolder structure required).
-    if not (DATA_ROOT / "Train").exists() or not (DATA_ROOT / "Validation").exists():
-        console.print(f"[bold red]Dataset not found under[/] {DATA_ROOT}")
+    device_obj = torch.device(device)
+    resume_requested = os.environ.get("DD_RESUME_AUTO") == "1"
+    resume_state = load_checkpoint(latest_ckpt_path, device_obj) if resume_requested else None
+
+    if not (data_root / train_split).exists() or not (data_root / val_split).exists():
+        console.print(f"[bold red]Dataset not found under[/] {data_root}")
         console.print(
-            "Expected: Dataset/Train/{Real,Fake} and Dataset/Validation/{Real,Fake}",
+            f"Expected: {train_split}/ and {val_split}/ folders with class subdirectories",
         )
         raise SystemExit(1)
 
-    train_dl, val_dl = get_loaders(DATA_ROOT, IMG_SIZE, BATCH_SIZE)
+    train_dl, val_dl = get_loaders(
+        data_root,
+        img_size,
+        batch_size,
+        train_split=train_split,
+        val_split=val_split,
+        num_workers=num_workers,
+    )
     console.print(
         f"[bold]Data[/]: train={len(train_dl.dataset)} | val={len(val_dl.dataset)} | "
-        f"bs={BATCH_SIZE} | steps/epoch={len(train_dl)}",
+        f"bs={batch_size} | steps/epoch={len(train_dl)}",
     )
 
-    # Model: start from ImageNet-pretrained backbone; set 2-class head.
-    model = timm.create_model(MODEL_NAME, pretrained=True, num_classes=2)
+    model = timm.create_model(MODEL_NAME, pretrained=True, num_classes=num_classes)
     model.to(memory_format=torch.channels_last)
-    model = model.to(device)
+    model = model.to(device_obj)
 
-    # Phase 1: freeze backbone, train classification head only.
-    for name, param in model.named_parameters():
-        param.requires_grad = ("classifier" in name) or ("head" in name)
+    if resume_state is not None and "model" in resume_state:
+        model.load_state_dict(resume_state["model"])
+        console.print("[bold]Loaded checkpoint weights from latest.ckpt[/]")
 
     criterion: nn.Module = nn.CrossEntropyLoss(label_smoothing=0.1)
-    head_params = [p for p in model.parameters() if p.requires_grad]
-    opt = optim.AdamW(head_params, lr=3e-4, weight_decay=5e-2)
     scaler = torch.amp.GradScaler(enabled=use_cuda)
 
-    # Progress UI.
     progress = Progress(
         TextColumn("[bold blue]{task.description}"),
         BarColumn(bar_width=None),
@@ -206,50 +321,92 @@ def main() -> None:  # noqa: PLR0915
         transient=False,
     )
 
+    best_val_acc = float(resume_state.get("best_val_acc", -1.0)) if resume_state else -1.0
+    best_epoch = int(resume_state.get("best_epoch", -1)) if resume_state else -1
+
+    warmup_completed = False
+    if resume_state is not None and resume_state.get("phase") in {"warmup", "finetune"}:
+        warmup_completed = True
+
     with progress:
-        # Warmup epoch (head only).
-        warmup_task = progress.add_task("warmup", total=len(train_dl), extra="")
-        console.print("[bold]Warmup (head only)[/]")
-        start = perf_counter()
+        if not warmup_completed:
+            for name, param in model.named_parameters():
+                param.requires_grad = ("classifier" in name) or ("head" in name)
 
-        model.train()
-        for i, (batch_x, batch_y) in enumerate(train_dl, 1):
-            inputs = batch_x.to(device, non_blocking=True).to(
-                memory_format=torch.channels_last,
-            )
-            targets = batch_y.to(device, non_blocking=True)
-            opt.zero_grad(set_to_none=True)
-            with torch.amp.autocast(device_type="cuda", enabled=use_cuda):
-                loss = criterion(model(inputs), targets)
-            scaler.scale(loss).backward()
-            scaler.step(opt)
-            scaler.update()
+            head_params = [p for p in model.parameters() if p.requires_grad]
+            opt = optim.AdamW(head_params, lr=3e-4, weight_decay=5e-2)
 
-            elapsed = perf_counter() - start
-            seen = min(i * train_dl.batch_size, len(train_dl.dataset))
-            ips = seen / max(1e-6, elapsed)
-            progress.update(
-                warmup_task,
-                advance=1,
-                description=f"warmup | loss={loss.item():.4f}",
-                extra=f"{ips:.0f} img/s",
+            warm_task = progress.add_task("warmup", total=len(train_dl), extra="")
+            console.print("[bold]Warmup (head only)[/]")
+            train_one_epoch(
+                model=model,
+                dl=train_dl,
+                opt=opt,
+                scaler=scaler,
+                criterion=criterion,
+                device=device,
+                use_cuda_amp=use_cuda,
+                progress=progress,
+                task=warm_task,
             )
 
-        # Phase 2: unfreeze late-stage layers + head and fine-tune.
-        for p in model.parameters():
-            p.requires_grad = False
-        for name, p in model.named_parameters():
+            warmup_acc = evaluate(model, val_dl, device)
+            console.print(f"[bold cyan]warmup[/] | val_acc={warmup_acc:.4f}")
+            best_val_acc = warmup_acc
+            best_epoch = 0
+            save_checkpoint(
+                latest_ckpt_path,
+                model=model,
+                optimizer=opt,
+                scheduler=None,
+                epoch=0,
+                phase="warmup",
+                best_val_acc=best_val_acc,
+                best_epoch=best_epoch,
+            )
+            save_checkpoint(
+                best_ckpt_path,
+                model=model,
+                optimizer=opt,
+                scheduler=None,
+                epoch=0,
+                phase="warmup",
+                best_val_acc=best_val_acc,
+                best_epoch=best_epoch,
+            )
+            torch.save(model.state_dict(), best_weights_path)
+        else:
+            console.print("[bold]Skipping warmup[/]: restored from checkpoint")
+
+        for param in model.parameters():
+            param.requires_grad = False
+        for name, param in model.named_parameters():
             if any(key in name for key in UNFREEZE_KEYS):
-                p.requires_grad = True
+                param.requires_grad = True
 
         opt = optim.AdamW(
             (p for p in model.parameters() if p.requires_grad),
             lr=1e-4,
             weight_decay=5e-2,
         )
-        scheduler = optim.lr_scheduler.CosineAnnealingLR(opt, T_max=max(1, EPOCHS - 1))
+        scheduler = optim.lr_scheduler.CosineAnnealingLR(opt, T_max=max(1, epochs - 1))
 
-        for epoch in range(1, EPOCHS):
+        start_epoch = 1
+        if resume_state is not None and resume_state.get("phase") == "finetune":
+            start_epoch = int(resume_state.get("epoch", 0)) + 1
+            opt_state = resume_state.get("optimizer")
+            if opt_state:
+                opt.load_state_dict(opt_state)
+            sched_state = resume_state.get("scheduler")
+            if sched_state:
+                scheduler.load_state_dict(sched_state)
+            console.print(f"[bold]Resuming fine-tune from epoch[/] {start_epoch}")
+
+        if start_epoch > EPOCHS:
+            console.print("[bold yellow]Nothing to do[/]: already finished training")
+            return
+
+        for epoch in range(start_epoch, EPOCHS + 1):
             task = progress.add_task(f"epoch {epoch}", total=len(train_dl), extra="")
             train_one_epoch(
                 model=model,
@@ -263,11 +420,42 @@ def main() -> None:  # noqa: PLR0915
                 task=task,
             )
             scheduler.step()
+
             acc = evaluate(model, val_dl, device)
             console.print(f"[bold cyan]epoch {epoch}[/] | val_acc={acc:.4f}")
 
-    torch.save(model.state_dict(), OUTPUT_WEIGHTS)
-    console.print(f"[bold green]Saved weights →[/] {OUTPUT_WEIGHTS.resolve()}")
+            if acc > best_val_acc + 1e-4:
+                best_val_acc = acc
+                best_epoch = epoch
+                torch.save(model.state_dict(), best_weights_path)
+                save_checkpoint(
+                    best_ckpt_path,
+                    model=model,
+                    optimizer=opt,
+                    scheduler=scheduler,
+                    epoch=epoch,
+                    phase="finetune",
+                    best_val_acc=best_val_acc,
+                    best_epoch=best_epoch,
+                )
+                console.print(
+                    f"[bold green]new best[/] val_acc={best_val_acc:.4f} → saved {best_weights_path.name}",
+                )
+
+            save_checkpoint(
+                latest_ckpt_path,
+                model=model,
+                optimizer=opt,
+                scheduler=scheduler,
+                epoch=epoch,
+                phase="finetune",
+                best_val_acc=best_val_acc,
+                best_epoch=best_epoch,
+            )
+
+    console.print(f"[bold green]Best weights saved →[/] {best_weights_path.resolve()}")
+    console.print(f"[bold green]Best checkpoint saved →[/] {best_ckpt_path.resolve()}")
+
 
 
 if __name__ == "__main__":

--- a/models/efficientnet/train.py
+++ b/models/efficientnet/train.py
@@ -19,10 +19,14 @@ This script saves:
 
 from __future__ import annotations
 
+import os
+import random
 from dataclasses import dataclass
 from pathlib import Path
 from time import perf_counter
+from typing import Any
 
+import numpy as np
 import torch
 from efficientnet_pytorch import EfficientNet
 from rich.console import Console
@@ -36,13 +40,14 @@ from rich.progress import (
     TimeRemainingColumn,
 )
 from torch import nn, optim
+from torch.optim.lr_scheduler import LRScheduler
 from torch.utils.data import DataLoader
 from torchvision import datasets, transforms
 
 # ---------------------------- Config --------------------------------- #
 
 # Adjust for your environment if needed.
-DATA_ROOT: Path = Path.home() / "code" / "DeepfakeDetection" / "data" / "Dataset"
+DEFAULT_DATA_ROOT: Path = Path.home() / "code" / "DeepfakeDetection" / "data" / "Dataset"
 
 # Training hyperparameters.
 EPOCHS: int = 25
@@ -59,10 +64,10 @@ FT_WD: float = 5e-2
 # Early stopping by Validation accuracy.
 PATIENCE: int = 4  # epochs without improvement
 
-# Output paths.
-BEST_WEIGHTS: Path = Path("EfficientNetModel.pth")
-BEST_CKPT: Path = Path("checkpoints") / "efficientnet_best.ckpt"
-BEST_CKPT.parent.mkdir(parents=True, exist_ok=True)
+# Default output paths (overridden by DD_OUTPUT_DIR when orchestrated).
+DEFAULT_WEIGHTS_NAME: str = "efficientnet_weights.pth"
+DEFAULT_LATEST_CKPT: str = "latest.ckpt"
+DEFAULT_BEST_CKPT: str = "best.ckpt"
 
 # Optional: gradient accumulation (helps laptops with limited VRAM)
 FT_BATCH_SIZE: int = 32  # micro-batch size during fine-tune
@@ -84,10 +89,60 @@ class EvalResult:
     correct: int
 
 
+def set_seed(seed: int) -> None:
+    """Seed Python, NumPy, and PyTorch for reproducible experiments."""
+
+    random.seed(seed)
+    np.random.seed(seed)
+    torch.manual_seed(seed)
+    torch.cuda.manual_seed_all(seed)
+    torch.backends.cudnn.deterministic = True
+    torch.backends.cudnn.benchmark = False
+
+
+def save_checkpoint(
+    path: Path,
+    *,
+    model: nn.Module,
+    optimizer: optim.Optimizer | None,
+    scheduler: LRScheduler | None,
+    epoch: int,
+    phase: str,
+    best_val_acc: float,
+    best_epoch: int,
+    epochs_no_improve: int,
+) -> None:
+    """Persist the latest training state so orchestration can resume runs."""
+
+    state: dict[str, Any] = {
+        "epoch": epoch,
+        "phase": phase,
+        "model": model.state_dict(),
+        "optimizer": optimizer.state_dict() if optimizer is not None else None,
+        "scheduler": scheduler.state_dict() if scheduler is not None else None,
+        "best_val_acc": best_val_acc,
+        "best_epoch": best_epoch,
+        "epochs_no_improve": epochs_no_improve,
+    }
+    torch.save(state, path)
+
+
+def load_checkpoint(path: Path, device: torch.device) -> dict[str, Any] | None:
+    """Load a checkpoint if it exists."""
+
+    if not path.exists():
+        return None
+    return torch.load(path, map_location=device)
+
+
 def get_loaders(
     data_root: Path,
     img_size: int,
     batch_size: int,
+    *,
+    train_split: str,
+    val_split: str,
+    num_workers: int,
 ) -> tuple[DataLoader, DataLoader]:
     """Build train/validation loaders. EfficientNet expects ImageNet norm."""
     train_t = transforms.Compose(
@@ -121,26 +176,32 @@ def get_loaders(
         ],
     )
 
-    train_ds = datasets.ImageFolder(data_root / "Train", transform=train_t)
-    val_ds = datasets.ImageFolder(data_root / "Validation", transform=val_t)
+    train_ds = datasets.ImageFolder(data_root / train_split, transform=train_t)
+    val_ds = datasets.ImageFolder(data_root / val_split, transform=val_t)
+
+    loader_kwargs = {
+        "num_workers": num_workers,
+        "pin_memory": True,
+        "persistent_workers": num_workers > 0,
+    }
+    if num_workers > 0:
+        loader_kwargs["prefetch_factor"] = 2
 
     train_dl = DataLoader(
         train_ds,
         batch_size=batch_size,
         shuffle=True,
-        num_workers=NUM_WORKERS,
-        pin_memory=True,
-        persistent_workers=NUM_WORKERS > 0,
-        prefetch_factor=2,
+        **loader_kwargs,
     )
+    val_loader_kwargs = loader_kwargs.copy()
+    val_loader_kwargs.pop("prefetch_factor", None)
+    if num_workers > 0:
+        val_loader_kwargs["prefetch_factor"] = 2
     val_dl = DataLoader(
         val_ds,
         batch_size=batch_size,
         shuffle=False,
-        num_workers=NUM_WORKERS,
-        pin_memory=True,
-        persistent_workers=NUM_WORKERS > 0,
-        prefetch_factor=2,
+        **val_loader_kwargs,
     )
     return train_dl, val_dl
 
@@ -245,63 +306,127 @@ def train_one_epoch(  # noqa: PLR0913
 
 
 def save_best(
+    *,
     model: nn.Module,
     opt: optim.Optimizer,
-    sched: optim.lr_scheduler._LRScheduler | None,
+    sched: LRScheduler | None,
     epoch: int,
+    best_weights_path: Path,
+    best_ckpt_path: Path,
+    best_val_acc: float,
+    best_epoch: int,
+    epochs_no_improve: int,
 ) -> None:
     """Persist best weights and a full resume checkpoint."""
-    torch.save(model.state_dict(), BEST_WEIGHTS)
+    torch.save(model.state_dict(), best_weights_path)
     ckpt = {
         "epoch": epoch,
+        "phase": "finetune",
         "model": model.state_dict(),
         "optimizer": opt.state_dict(),
         "scheduler": sched.state_dict() if sched is not None else None,
+        "best_val_acc": best_val_acc,
+        "best_epoch": best_epoch,
+        "epochs_no_improve": epochs_no_improve,
     }
-    torch.save(ckpt, BEST_CKPT)
+    torch.save(ckpt, best_ckpt_path)
 
 
 def main() -> None:  # noqa: PLR0915
     """Entrypoint: data, model, warmup, fine-tune, early stop, save best."""
-    # Device
-    torch.backends.cudnn.benchmark = True  # faster kernels on stable shapes
-    use_cuda = torch.cuda.is_available()
-    device = "cuda" if use_cuda else "cpu"
+
+    output_dir = Path(os.environ.get("DD_OUTPUT_DIR", ".")).expanduser().resolve()
+    checkpoints_dir = output_dir / "checkpoints"
+    logs_dir = output_dir / "logs"
+    for path in (output_dir, checkpoints_dir, logs_dir):
+        path.mkdir(parents=True, exist_ok=True)
+
+    best_weights_path = checkpoints_dir / DEFAULT_WEIGHTS_NAME
+    latest_ckpt_path = checkpoints_dir / DEFAULT_LATEST_CKPT
+    best_ckpt_path = checkpoints_dir / DEFAULT_BEST_CKPT
+
+    data_root = Path(os.environ.get("DD_DATA_ROOT", DEFAULT_DATA_ROOT)).expanduser()
+    train_split = os.environ.get("DD_TRAIN_SPLIT", "Train")
+    val_split = os.environ.get("DD_VAL_SPLIT", "Validation")
+
+    img_size = int(os.environ.get("DD_IMG_SIZE", IMG_SIZE))
+    batch_size = int(os.environ.get("DD_BATCH_SIZE", BATCH_SIZE))
+    epochs = int(os.environ.get("DD_EPOCHS", EPOCHS))
+    num_workers = int(os.environ.get("DD_NUM_WORKERS", NUM_WORKERS))
+    num_classes = int(os.environ.get("DD_NUM_CLASSES", 2))
+
+    seed_env = os.environ.get("DD_SEED")
+    seeded = False
+    if seed_env is not None:
+        try:
+            seed_value = int(seed_env)
+        except ValueError:
+            console.print(f"[bold yellow]Invalid DD_SEED[/]: {seed_env}")
+        else:
+            set_seed(seed_value)
+            seeded = True
+            console.print(f"[bold]Seeded[/]: {seed_value}")
+
+    device_env = os.environ.get("DD_DEVICE")
+    if device_env:
+        device = device_env
+        use_cuda = device.startswith("cuda") and torch.cuda.is_available()
+        if device.startswith("cuda") and not torch.cuda.is_available():
+            console.print(
+                "[bold yellow]⚠️  Requested CUDA device unavailable[/]: falling back to CPU",
+            )
+            device = "cpu"
+            use_cuda = False
+    else:
+        use_cuda = torch.cuda.is_available()
+        device = "cuda" if use_cuda else "cpu"
+
     if use_cuda:
+        if not seeded:
+            torch.backends.cudnn.benchmark = True
         console.print("[bold green]✅ CUDA available[/]: using GPU")
         console.print(f"Device: {torch.cuda.get_device_name(0)}")
     else:
         console.print("[bold yellow]⚠️  CUDA not available[/]: using CPU")
 
-    # Dataset presence check.
-    if not (DATA_ROOT / "Train").exists() or not (DATA_ROOT / "Validation").exists():
-        console.print(f"[bold red]Dataset not found under[/] {DATA_ROOT}")
+    device_obj = torch.device(device)
+    resume_requested = os.environ.get("DD_RESUME_AUTO") == "1"
+    resume_state = load_checkpoint(latest_ckpt_path, device_obj) if resume_requested else None
+
+    if not (data_root / train_split).exists() or not (data_root / val_split).exists():
+        console.print(f"[bold red]Dataset not found under[/] {data_root}")
         console.print(
-            "Expected: Dataset/Train/{Real,Fake} and Dataset/Validation/{Real,Fake}",
+            f"Expected: {train_split}/ and {val_split}/ folders with class subdirectories",
         )
         raise SystemExit(1)
 
-    # Data loaders
-    train_dl, val_dl = get_loaders(DATA_ROOT, IMG_SIZE, BATCH_SIZE)
+    train_dl, val_dl = get_loaders(
+        data_root,
+        img_size,
+        batch_size,
+        train_split=train_split,
+        val_split=val_split,
+        num_workers=num_workers,
+    )
     console.print(
         f"[bold]Data[/]: train={len(train_dl.dataset)} | val={len(val_dl.dataset)} | "
-        f"bs={BATCH_SIZE} | steps/epoch={len(train_dl)}",
+        f"bs={batch_size} | steps/epoch={len(train_dl)}",
     )
 
-    # Model: EfficientNet-B3 (ImageNet-pretrained), 2-class head.
     model = EfficientNet.from_pretrained("efficientnet-b3")
     in_features = model._fc.in_features  # noqa: SLF001
-    model._fc = nn.Linear(in_features, 2)  # noqa: SLF001
-    # EfficientNet already uses dropout internally.
+    model._fc = nn.Linear(in_features, num_classes)  # noqa: SLF001
 
     model.to(memory_format=torch.channels_last)
-    model = model.to(device)
+    model = model.to(device_obj)
 
-    # Loss, scaler
+    if resume_state is not None and "model" in resume_state:
+        model.load_state_dict(resume_state["model"])
+        console.print("[bold]Loaded checkpoint weights from latest.ckpt[/]")
+
     criterion: nn.Module = nn.CrossEntropyLoss(label_smoothing=0.1)
     scaler = torch.amp.GradScaler(enabled=use_cuda)
 
-    # Progress UI.
     progress = Progress(
         TextColumn("[bold blue]{task.description}"),
         BarColumn(bar_width=None),
@@ -313,67 +438,98 @@ def main() -> None:  # noqa: PLR0915
         transient=False,
     )
 
-    best_val_acc = -1.0
-    best_epoch = -1
-    epochs_no_improve = 0
+    best_val_acc = float(resume_state.get("best_val_acc", -1.0)) if resume_state else -1.0
+    best_epoch = int(resume_state.get("best_epoch", -1)) if resume_state else -1
+    epochs_no_improve = int(resume_state.get("epochs_no_improve", 0)) if resume_state else 0
+
+    warmup_completed = False
+    if resume_state is not None and resume_state.get("phase") in {"warmup", "finetune"}:
+        warmup_completed = True
 
     with progress:
-        # ---------------------- Phase 1: head warmup ---------------------- #
-        for p in model.parameters():
-            p.requires_grad = False
-        for n, p in model.named_parameters():
-            if "_fc" in n:
-                p.requires_grad = True
+        if not warmup_completed:
+            for param in model.parameters():
+                param.requires_grad = False
+            for name, param in model.named_parameters():
+                if "_fc" in name:
+                    param.requires_grad = True
 
-        head_params = [p for p in model.parameters() if p.requires_grad]
-        opt = optim.AdamW(head_params, lr=HEAD_LR, weight_decay=HEAD_WD)
+            head_params = [p for p in model.parameters() if p.requires_grad]
+            opt = optim.AdamW(head_params, lr=HEAD_LR, weight_decay=HEAD_WD)
 
-        warm_task = progress.add_task(
-            "warmup (head only)",
-            total=len(train_dl),
-            extra="",
-        )
-        console.print("[bold]Warmup (head only)[/]")
-        _ = train_one_epoch(
-            model=model,
-            dl=train_dl,
-            opt=opt,
-            scaler=scaler,
-            criterion=criterion,
-            device=device,
-            use_cuda_amp=use_cuda,
-            progress=progress,
-            task=warm_task,
-            accum_steps=1,
-        )
+            warm_task = progress.add_task(
+                "warmup (head only)",
+                total=len(train_dl),
+                extra="",
+            )
+            console.print("[bold]Warmup (head only)[/]")
+            _ = train_one_epoch(
+                model=model,
+                dl=train_dl,
+                opt=opt,
+                scaler=scaler,
+                criterion=criterion,
+                device=device,
+                use_cuda_amp=use_cuda,
+                progress=progress,
+                task=warm_task,
+                accum_steps=1,
+            )
 
-        # Validate after warmup
-        res = evaluate(model, val_dl, device, criterion)
-        console.print(
-            f"[bold cyan]warmup[/] | val_acc={res.acc:.4f} | val_loss={res.loss:.4f} "
-            f"({res.correct}/{res.total})",
-        )
-        best_val_acc = res.acc
-        best_epoch = 0
-        save_best(model, opt, sched=None, epoch=best_epoch)
+            res = evaluate(model, val_dl, device, criterion)
+            console.print(
+                f"[bold cyan]warmup[/] | val_acc={res.acc:.4f} | val_loss={res.loss:.4f} "
+                f"({res.correct}/{res.total})",
+            )
+            best_val_acc = res.acc
+            best_epoch = 0
+            epochs_no_improve = 0
+            save_checkpoint(
+                latest_ckpt_path,
+                model=model,
+                optimizer=opt,
+                scheduler=None,
+                epoch=0,
+                phase="warmup",
+                best_val_acc=best_val_acc,
+                best_epoch=best_epoch,
+                epochs_no_improve=epochs_no_improve,
+            )
+            save_checkpoint(
+                best_ckpt_path,
+                model=model,
+                optimizer=opt,
+                scheduler=None,
+                epoch=0,
+                phase="warmup",
+                best_val_acc=best_val_acc,
+                best_epoch=best_epoch,
+                epochs_no_improve=epochs_no_improve,
+            )
+            torch.save(model.state_dict(), best_weights_path)
+        else:
+            console.print("[bold]Skipping warmup[/]: restored from checkpoint")
 
-        # -------------------- Phase 2: full fine-tune --------------------- #
-        for p in model.parameters():
-            p.requires_grad = True
+        for param in model.parameters():
+            param.requires_grad = True
 
-        # Smaller fine-tune micro-batch for laptop VRAM + gradient accumulation
         console.print(
             f"[bold]Fine-tune[/]: bs={FT_BATCH_SIZE}, accum_steps={ACCUM_STEPS} "
             f"(effective ≈ {FT_BATCH_SIZE * ACCUM_STEPS})",
         )
+        train_dataset = train_dl.dataset
+        ft_loader_kwargs = {
+            "num_workers": num_workers,
+            "pin_memory": True,
+            "persistent_workers": num_workers > 0,
+        }
+        if num_workers > 0:
+            ft_loader_kwargs["prefetch_factor"] = 2
         train_dl_ft = DataLoader(
-            train_dl.dataset,
+            train_dataset,
             batch_size=FT_BATCH_SIZE,
             shuffle=True,
-            num_workers=NUM_WORKERS,
-            pin_memory=True,
-            persistent_workers=NUM_WORKERS > 0,
-            prefetch_factor=2,
+            **ft_loader_kwargs,
         )
 
         opt = optim.AdamW(
@@ -381,9 +537,24 @@ def main() -> None:  # noqa: PLR0915
             lr=FT_LR,
             weight_decay=FT_WD,
         )
-        scheduler = optim.lr_scheduler.CosineAnnealingLR(opt, T_max=max(1, EPOCHS - 1))
+        scheduler = optim.lr_scheduler.CosineAnnealingLR(opt, T_max=max(1, epochs - 1))
 
-        for epoch in range(1, EPOCHS + 1):
+        start_epoch = 1
+        if resume_state is not None and resume_state.get("phase") == "finetune":
+            start_epoch = int(resume_state.get("epoch", 0)) + 1
+            opt_state = resume_state.get("optimizer")
+            if opt_state:
+                opt.load_state_dict(opt_state)
+            sched_state = resume_state.get("scheduler")
+            if sched_state:
+                scheduler.load_state_dict(sched_state)
+            console.print(f"[bold]Resuming fine-tune from epoch[/] {start_epoch}")
+
+        if start_epoch > epochs:
+            console.print("[bold yellow]Nothing to do[/]: already finished training")
+            return
+
+        for epoch in range(start_epoch, epochs + 1):
             task = progress.add_task(f"epoch {epoch}", total=len(train_dl_ft), extra="")
             train_loss = train_one_epoch(
                 model=model,
@@ -411,10 +582,20 @@ def main() -> None:  # noqa: PLR0915
                 best_val_acc = res.acc
                 best_epoch = epoch
                 epochs_no_improve = 0
-                save_best(model, opt, scheduler, epoch)
+                save_best(
+                    model=model,
+                    opt=opt,
+                    sched=scheduler,
+                    epoch=epoch,
+                    best_weights_path=best_weights_path,
+                    best_ckpt_path=best_ckpt_path,
+                    best_val_acc=best_val_acc,
+                    best_epoch=best_epoch,
+                    epochs_no_improve=epochs_no_improve,
+                )
                 console.print(
                     f"[bold green]new best[/] val_acc={best_val_acc:.4f} "
-                    f"(epoch {best_epoch}) → saved {BEST_WEIGHTS.name}",
+                    f"(epoch {best_epoch}) → saved {best_weights_path.name}",
                 )
             else:
                 epochs_no_improve += 1
@@ -424,10 +605,34 @@ def main() -> None:  # noqa: PLR0915
                         f"{PATIENCE} epoch(s). Best at epoch {best_epoch} "
                         f"with val_acc={best_val_acc:.4f}.",
                     )
+                    save_checkpoint(
+                        latest_ckpt_path,
+                        model=model,
+                        optimizer=opt,
+                        scheduler=scheduler,
+                        epoch=epoch,
+                        phase="finetune",
+                        best_val_acc=best_val_acc,
+                        best_epoch=best_epoch,
+                        epochs_no_improve=epochs_no_improve,
+                    )
                     break
 
-    console.print(f"[bold green]Best weights saved →[/] {BEST_WEIGHTS.resolve()}")
-    console.print(f"[bold green]Best checkpoint saved →[/] {BEST_CKPT.resolve()}")
+            save_checkpoint(
+                latest_ckpt_path,
+                model=model,
+                optimizer=opt,
+                scheduler=scheduler,
+                epoch=epoch,
+                phase="finetune",
+                best_val_acc=best_val_acc,
+                best_epoch=best_epoch,
+                epochs_no_improve=epochs_no_improve,
+            )
+
+    console.print(f"[bold green]Best weights saved →[/] {best_weights_path.resolve()}")
+    console.print(f"[bold green]Best checkpoint saved →[/] {best_ckpt_path.resolve()}")
+
 
 
 if __name__ == "__main__":

--- a/orchestrator.py
+++ b/orchestrator.py
@@ -1,0 +1,193 @@
+"""Simple runner to orchestrate training and inference jobs."""
+
+from __future__ import annotations
+
+import argparse
+import os
+import random
+import subprocess
+import sys
+from datetime import datetime
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+import torch
+import yaml
+from rich.console import Console
+
+from model_zoo import get_model_spec
+
+console = Console()
+REPO_ROOT = Path(__file__).resolve().parent
+
+
+def load_config(path: Path) -> dict[str, Any]:
+    with path.open("r", encoding="utf-8") as handle:
+        return yaml.safe_load(handle)
+
+
+def set_global_seed(seed: int) -> None:
+    random.seed(seed)
+    np.random.seed(seed)
+    torch.manual_seed(seed)
+    torch.cuda.manual_seed_all(seed)
+    torch.backends.cudnn.deterministic = True
+    torch.backends.cudnn.benchmark = False
+
+
+def ensure_run_dir(base: Path, timestamp: str) -> Path:
+    run_dir = base / timestamp
+    for sub in (run_dir, run_dir / "checkpoints", run_dir / "logs", run_dir / "plots"):
+        sub.mkdir(parents=True, exist_ok=True)
+    return run_dir
+
+
+def stream_subprocess(cmd: list[str], *, env: dict[str, str], cwd: Path, log_path: Path) -> int:
+    console.print(f"[bold blue]→ Running[/] {' '.join(cmd)}")
+    with log_path.open("w", encoding="utf-8") as log_file:
+        process = subprocess.Popen(
+            cmd,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+            text=True,
+            cwd=str(cwd),
+            env=env,
+            bufsize=1,
+        )
+        assert process.stdout is not None
+        for line in process.stdout:
+            log_file.write(line)
+            console.print(line.rstrip())
+        return_code = process.wait()
+    if return_code != 0:
+        console.print(f"[bold red]Command failed with code {return_code}[/]")
+    return return_code
+
+
+def prepare_environment(
+    *,
+    config: dict[str, Any],
+    model_cfg: dict[str, Any],
+    run_dir: Path,
+    training: bool,
+) -> dict[str, str]:
+    env = os.environ.copy()
+    env["PYTHONPATH"] = f"{REPO_ROOT}:{env.get('PYTHONPATH', '')}" if env.get("PYTHONPATH") else str(REPO_ROOT)
+    env["DD_OUTPUT_DIR"] = str(run_dir)
+
+    if "seed" in config:
+        env["DD_SEED"] = str(config["seed"])
+
+    device = config.get("device")
+    if device:
+        env["DD_DEVICE"] = str(device)
+
+    data_cfg = config.get("data", {})
+    data_root = data_cfg.get("root")
+    if data_root:
+        env["DD_DATA_ROOT"] = str(Path(data_root).expanduser().resolve())
+    if "train_split" in data_cfg:
+        env["DD_TRAIN_SPLIT"] = str(data_cfg["train_split"])
+    if "val_split" in data_cfg:
+        env["DD_VAL_SPLIT"] = str(data_cfg["val_split"])
+
+    num_classes = model_cfg.get("num_classes", data_cfg.get("num_classes"))
+    if num_classes is not None:
+        env["DD_NUM_CLASSES"] = str(num_classes)
+    if "img_size" in data_cfg:
+        env["DD_IMG_SIZE"] = str(data_cfg["img_size"])
+
+    if training:
+        train_cfg = model_cfg.get("training", {})
+        if "batch_size" in train_cfg:
+            env["DD_BATCH_SIZE"] = str(train_cfg["batch_size"])
+        if "epochs" in train_cfg:
+            env["DD_EPOCHS"] = str(train_cfg["epochs"])
+        if "num_workers" in train_cfg:
+            env["DD_NUM_WORKERS"] = str(train_cfg["num_workers"])
+        resume = str(train_cfg.get("resume", "")).lower()
+        env["DD_RESUME_AUTO"] = "1" if resume in {"1", "true", "auto"} else "0"
+    else:
+        infer_cfg = model_cfg.get("inference", {})
+        if "batch_size" in infer_cfg:
+            env["DD_BATCH_SIZE"] = str(infer_cfg["batch_size"])
+        if "num_workers" in infer_cfg:
+            env["DD_NUM_WORKERS"] = str(infer_cfg["num_workers"])
+
+    return env
+
+
+def snapshot_config(run_dir: Path, *, config: dict[str, Any], model_cfg: dict[str, Any]) -> None:
+    snapshot = {
+        "timestamp": datetime.now().isoformat(),
+        "global": {k: v for k, v in config.items() if k != "models"},
+        "model": model_cfg,
+    }
+    with (run_dir / "config_snapshot.yaml").open("w", encoding="utf-8") as handle:
+        yaml.safe_dump(snapshot, handle)
+
+
+def run_training(config: dict[str, Any], model_cfg: dict[str, Any], run_dir: Path) -> None:
+    spec = get_model_spec(model_cfg["name"])
+    env = prepare_environment(config=config, model_cfg=model_cfg, run_dir=run_dir, training=True)
+    cmd = [sys.executable, str((REPO_ROOT / spec.train_script).resolve())]
+    log_path = run_dir / "logs" / "train.log"
+    return_code = stream_subprocess(cmd, env=env, cwd=run_dir, log_path=log_path)
+    if return_code != 0:
+        raise SystemExit(return_code)
+
+
+def run_inference(config: dict[str, Any], model_cfg: dict[str, Any], run_dir: Path, config_path: Path) -> None:
+    env = prepare_environment(config=config, model_cfg=model_cfg, run_dir=run_dir, training=False)
+    cmd = [
+        sys.executable,
+        str((REPO_ROOT / "inference_cli.py").resolve()),
+        "--config",
+        str(config_path),
+        "--model-name",
+        model_cfg["name"],
+        "--run-dir",
+        str(run_dir),
+    ]
+    log_path = run_dir / "logs" / "inference.log"
+    return_code = stream_subprocess(cmd, env=env, cwd=run_dir, log_path=log_path)
+    if return_code != 0:
+        raise SystemExit(return_code)
+
+
+def orchestrate(config_path: Path) -> None:
+    config = load_config(config_path)
+    mode = config.get("mode", "training").lower()
+
+    seed = config.get("seed")
+    if seed is not None:
+        set_global_seed(int(seed))
+
+    for model_cfg in config.get("models", []):
+        if not model_cfg.get("enabled", True):
+            continue
+        model_name = model_cfg["name"]
+        timestamp = datetime.now().strftime("%Y%m%d-%H%M%S")
+        base_output = Path(model_cfg.get("output_dir", f"runs/{model_name}"))
+        run_dir = ensure_run_dir(base_output, timestamp)
+        snapshot_config(run_dir, config=config, model_cfg=model_cfg)
+        console.print(f"[bold]Model[/]: {model_name} → run dir {run_dir}")
+
+        if mode == "training":
+            run_training(config, model_cfg, run_dir)
+        elif mode == "inference":
+            run_inference(config, model_cfg, run_dir, config_path)
+        else:
+            raise ValueError(f"Unknown mode '{mode}'")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="DeepfakeDetection orchestrator")
+    parser.add_argument("--config", default="config/run.yaml", type=Path)
+    args = parser.parse_args()
+    orchestrate(args.config.resolve())
+
+
+if __name__ == "__main__":
+    main()

--- a/pipeline.py
+++ b/pipeline.py
@@ -1,0 +1,106 @@
+"""Shared inference pipeline for headless deepfake detection."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import torch
+from PIL import Image
+from torch import nn
+from torchvision import transforms
+
+from model_zoo import ModelSpec, get_model_spec
+
+
+def _ensure_rgb(image: Image.Image) -> Image.Image:
+    if image.mode != "RGB":
+        return image.convert("RGB")
+    return image
+
+
+class DeepfakePipeline:
+    """Tiny helper around the model zoo for inference.
+
+    The pipeline keeps things deliberately light-weight: it knows how to build a
+    model architecture, load weights, prepare ImageNet-style transforms, and run
+    batched predictions. The default setup targets deepfake frame classification
+    but works for general ImageFolder datasets (e.g., MNIST variants converted to
+    RGB).
+    """
+
+    def __init__(self, device: str | torch.device = "cpu") -> None:
+        self.device = torch.device(device)
+        self.spec: ModelSpec | None = None
+        self.model: nn.Module | None = None
+        self.transforms: transforms.Compose | None = None
+
+    def load_model(
+        self,
+        model_name: str,
+        num_classes: int,
+        weights_path: str | Path | None,
+    ) -> nn.Module:
+        spec = get_model_spec(model_name)
+        model = spec.builder(model_name, num_classes)
+        model = model.to(self.device)
+        model.eval()
+
+        if weights_path is not None:
+            state = torch.load(Path(weights_path), map_location=self.device)
+            if isinstance(state, dict) and "state_dict" in state:
+                state = state["state_dict"]
+            elif isinstance(state, dict) and "model" in state:
+                state = state["model"]
+            model.load_state_dict(state, strict=False)
+
+        self.spec = spec
+        self.model = model
+        return model
+
+    def build_transforms(
+        self,
+        *,
+        eval: bool = True,
+        image_size: int | None = None,
+    ) -> transforms.Compose:
+        size = image_size
+        if size is None:
+            size = self.spec.default_image_size if self.spec else 224
+
+        if eval:
+            ops = [
+                transforms.Lambda(_ensure_rgb),
+                transforms.Resize(size),
+                transforms.CenterCrop(size),
+                transforms.ToTensor(),
+                transforms.Normalize(mean=[0.485, 0.456, 0.406], std=[0.229, 0.224, 0.225]),
+            ]
+        else:
+            ops = [
+                transforms.Lambda(_ensure_rgb),
+                transforms.RandomResizedCrop(size, scale=(0.8, 1.0)),
+                transforms.RandomHorizontalFlip(),
+                transforms.ToTensor(),
+                transforms.Normalize(mean=[0.485, 0.456, 0.406], std=[0.229, 0.224, 0.225]),
+            ]
+
+        self.transforms = transforms.Compose(ops)
+        return self.transforms
+
+    def predict_batch(self, batch: torch.Tensor) -> torch.Tensor:
+        if self.model is None:
+            msg = "Model not loaded. Call load_model() first."
+            raise RuntimeError(msg)
+        self.model.eval()
+        with torch.inference_mode():
+            inputs = batch.to(self.device, non_blocking=True)
+            return self.model(inputs)
+
+    @staticmethod
+    def postprocess(logits: torch.Tensor) -> tuple[torch.Tensor, torch.Tensor]:
+        probs = torch.softmax(logits, dim=1)
+        top1 = torch.argmax(probs, dim=1)
+        return probs, top1
+
+
+__all__ = ["DeepfakePipeline"]


### PR DESCRIPTION
## Summary
- add an orchestrator entrypoint that reads `config/run.yaml`, seeds runs, and launches training or inference with per-model run directories
- introduce a model registry, reusable inference pipeline, and headless CLI to run batched evaluation and capture metrics/plots for deepfake frame datasets
- teach existing training scripts to honor orchestrator environment overrides (data splits, loaders, resume, device) and document the workflow in the README with a sample config

## Testing
- ruff check
- pytest


Attempting to get this right with Codex!