### PR TITLE
Refine inference orchestration: env overrides and dataset class checks

### DIFF
--- a/orchestration/orchestrator.py
+++ b/orchestration/orchestrator.py
@@ -190,25 +190,25 @@ def build_env_overrides(
     data_cfg = config.get("data", {})
     train_cfg = model_cfg.get("training", {})
     infer_cfg = model_cfg.get("inference", {})
-    overrides: dict[str, str] = {"DD_OUTPUT_DIR": str(run_paths.run_dir)}
+    overrides: dict[str, str] = {"OUTPUT_DIR": str(run_paths.run_dir)}
 
     seed = config.get("seed")
     if seed is not None:
-        overrides["DD_SEED"] = str(seed)
+        overrides["SEED"] = str(seed)
 
     device = config.get("device")
     if device:
-        overrides["DD_DEVICE"] = str(device)
+        overrides["DEVICE"] = str(device)
 
     data_root = data_cfg.get("root")
     if data_root:
-        overrides["DD_DATA_ROOT"] = str(Path(data_root).expanduser().resolve())
+        overrides["DATA_ROOT"] = str(Path(data_root).expanduser().resolve())
     for key, env_key in (
-        ("train_split", "DD_TRAIN_SPLIT"),
-        ("val_split", "DD_VAL_SPLIT"),
-        ("test_split", "DD_TEST_SPLIT"),
-        ("img_size", "DD_IMG_SIZE"),
-        ("num_classes", "DD_NUM_CLASSES"),
+        ("train_split", "TRAIN_SPLIT"),
+        ("val_split", "VAL_SPLIT"),
+        ("test_split", "TEST_SPLIT"),
+        ("img_size", "IMG_SIZE"),
+        ("num_classes", "NUM_CLASSES"),
     ):
         value = data_cfg.get(key)
         if value is not None:
@@ -219,20 +219,20 @@ def build_env_overrides(
         model_cfg.get("num_classes", data_cfg.get("num_classes")),
     )
     if num_classes is not None:
-        overrides["DD_NUM_CLASSES"] = str(num_classes)
+        overrides["NUM_CLASSES"] = str(num_classes)
 
     if training:
         if "batch_size" in train_cfg:
-            overrides["DD_BATCH_SIZE"] = str(train_cfg["batch_size"])
+            overrides["BATCH_SIZE"] = str(train_cfg["batch_size"])
         if "epochs" in train_cfg:
-            overrides["DD_EPOCHS"] = str(train_cfg["epochs"])
+            overrides["EPOCHS"] = str(train_cfg["epochs"])
         if "num_workers" in train_cfg:
-            overrides["DD_NUM_WORKERS"] = str(train_cfg["num_workers"])
+            overrides["NUM_WORKERS"] = str(train_cfg["num_workers"])
         img_override = train_cfg.get("img_size")
         if img_override is not None:
-            overrides["DD_IMG_SIZE"] = str(img_override)
+            overrides["IMG_SIZE"] = str(img_override)
         resume_flag = str(train_cfg.get("resume", "")).lower()
-        overrides["DD_RESUME_AUTO"] = (
+        overrides["RESUME_AUTO"] = (
             "1" if resume_flag in {"1", "true", "auto"} else "0"
         )
     else:
@@ -240,33 +240,33 @@ def build_env_overrides(
 
         split_override = infer_cfg.get("split")
         if split_override:
-            overrides["DD_TEST_SPLIT"] = str(split_override)
+            overrides["TEST_SPLIT"] = str(split_override)
 
         batch_size = infer_cfg.get("batch_size")
         if batch_size is None:
             batch_size = train_cfg.get("batch_size")
         if batch_size is None:
             batch_size = 64
-        overrides["DD_BATCH_SIZE"] = str(batch_size)
+        overrides["BATCH_SIZE"] = str(batch_size)
 
         num_workers = infer_cfg.get("num_workers")
         if num_workers is None:
             num_workers = train_cfg.get("num_workers")
         if num_workers is None:
             num_workers = data_cfg.get("num_workers", 0)
-        overrides["DD_NUM_WORKERS"] = str(num_workers)
+        overrides["NUM_WORKERS"] = str(num_workers)
 
         image_size = infer_cfg.get("img_size")
         if image_size is None:
             image_size = train_cfg.get("img_size")
         if image_size is None:
             image_size = data_cfg.get("img_size", spec.default_image_size)
-        overrides["DD_IMG_SIZE"] = str(image_size)
+        overrides["IMG_SIZE"] = str(image_size)
 
     phase_key = "train" if training else "eval"
     transform_overrides = resolve_transform_mapping(model_cfg, phase=phase_key)
     if transform_overrides:
-        overrides["DD_TRANSFORMS"] = json.dumps(transform_overrides)
+        overrides["TRANSFORMS"] = json.dumps(transform_overrides)
 
     return overrides
 
@@ -288,7 +288,7 @@ def run_training_job(
     )
     log_path = run_paths.logs / "train.log"
     log_path.unlink(missing_ok=True)
-    overrides["DD_LOG_PATH"] = str(log_path)
+    overrides["LOG_PATH"] = str(log_path)
     console.print(f"[bold]→ training {model_cfg['name']}[/]")
     with patched_environ(overrides):
         trainer_main = import_trainer(spec.train_module)

--- a/orchestration/train_env.py
+++ b/orchestration/train_env.py
@@ -79,9 +79,9 @@ class _TeeStream(io.TextIOBase):
 
 
 def create_console(*, width: int | None = None) -> Console:
-    """Build a Rich console that mirrors output to ``DD_LOG_PATH`` if provided."""
+    """Build a Rich console that mirrors output to ``LOG_PATH`` if provided."""
 
-    log_path_value = os.environ.get("DD_LOG_PATH")
+    log_path_value = os.environ.get("LOG_PATH")
     stream: io.TextIOBase = sys.stdout
     if log_path_value:
         log_path = Path(log_path_value).expanduser()
@@ -110,7 +110,7 @@ def _as_bool(value: Any) -> bool:
 def load_transform_toggles(
     defaults: dict[str, bool],
     *,
-    env_var: str = "DD_TRANSFORMS",
+    env_var: str = "TRANSFORMS",
     required: Sequence[str] | None = None,
 ) -> dict[str, bool]:
     """Return per-transform enable flags supplied via environment variables.
@@ -162,13 +162,13 @@ def prepare_training_environment(
         Filename used when saving the best model weights.
     default_output_dir:
         Where to place outputs when the orchestrator does not set
-        ``DD_OUTPUT_DIR``. Defaults to the current working directory.
+        ``OUTPUT_DIR``. Defaults to the current working directory.
     best_checkpoint_name / latest_checkpoint_name:
         Filenames for checkpoint files within the checkpoints directory.
     """
 
     base_dir = Path(
-        os.environ.get("DD_OUTPUT_DIR", default_output_dir or Path.cwd())
+        os.environ.get("OUTPUT_DIR", default_output_dir or Path.cwd())
     ).expanduser().resolve()
     checkpoints_dir = base_dir / "checkpoints"
     logs_dir = base_dir / "logs"
@@ -179,13 +179,13 @@ def prepare_training_environment(
     best_checkpoint_path = checkpoints_dir / best_checkpoint_name
     latest_checkpoint_path = checkpoints_dir / latest_checkpoint_name
 
-    resume_flag = os.environ.get("DD_RESUME_AUTO", "").strip()
+    resume_flag = os.environ.get("RESUME_AUTO", "").strip()
     resume_checkpoint: Path | None = None
     if resume_flag == "1" and latest_checkpoint_path.exists():
         resume_checkpoint = latest_checkpoint_path
 
-    seed = int(os.environ["DD_SEED"]) if "DD_SEED" in os.environ else None
-    device_override = os.environ.get("DD_DEVICE")
+    seed = int(os.environ["SEED"]) if "SEED" in os.environ else None
+    device_override = os.environ.get("DEVICE")
 
     return TrainingEnvironment(
         output_dir=base_dir,
@@ -322,7 +322,7 @@ def require_num_classes(
     raise ValueError(
         "Class count mismatch for split "
         f"'{split}'{root_hint}: dataset exposes {actual} classes ({preview}) "
-        f"but configuration sets DD_NUM_CLASSES={expected}. "
+        f"but configuration sets NUM_CLASSES={expected}. "
         "Update config.data.num_classes (e.g., match it to the true number of "
         "categories in your ImageFolder)."
     )

--- a/test.patch
+++ b/test.patch
@@ -1,0 +1,332 @@
+ (cd "$(git rev-parse --show-toplevel)" && git apply --3way <<'EOF' 
+diff --git a/orchestration/orchestrator.py b/orchestration/orchestrator.py
+index f396b6b284c036f06653cf15980269986d306fa2..13d6eba562f698b7f15d29a45dd263a7ab81e42b 100644
+--- a/orchestration/orchestrator.py
++++ b/orchestration/orchestrator.py
+@@ -20,51 +20,51 @@ import matplotlib.pyplot as plt
+ import numpy as np
+ import torch
+ import yaml
+ from PIL import Image
+ from rich.console import Console
+ from rich.progress import (
+     BarColumn,
+     MofNCompleteColumn,
+     Progress,
+     TextColumn,
+     TimeElapsedColumn,
+     TimeRemainingColumn,
+ )
+ from sklearn.metrics import (
+     ConfusionMatrixDisplay,
+     balanced_accuracy_score,
+     confusion_matrix,
+     roc_auc_score,
+ )
+ from torch import nn
+ from torch.utils.data import DataLoader
+ from torchvision import datasets, transforms
+ 
+ from .config_schema import OrchestratorConfig
+ from .model_registry import get_model_spec
+-from .train_env import apply_seed
++from .train_env import apply_seed, require_num_classes
+ 
+ console = Console()
+ 
+ 
+ @dataclass(frozen=True)
+ class RunPaths:
+     """Filesystem layout for a single model run."""
+ 
+     run_dir: Path
+     checkpoints: Path
+     logs: Path
+     plots: Path
+ 
+ 
+ @contextlib.contextmanager
+ def patched_environ(overrides: dict[str, str]) -> Iterator[None]:
+     """Temporarily set environment variables for a trainer."""
+     original: dict[str, str | None] = {}
+     for key, value in overrides.items():
+         original[key] = os.environ.get(key)
+         os.environ[key] = value
+     try:
+         yield
+     finally:
+         for key, value in original.items():
+@@ -166,102 +166,124 @@ def resolve_transform_mapping(
+     transforms_cfg = model_cfg.get("transforms")
+     if isinstance(transforms_cfg, dict):
+         phase_cfg = transforms_cfg.get(phase)
+         if isinstance(phase_cfg, dict):
+             return phase_cfg
+         if all(
+             isinstance(v, bool | int | float | str) for v in transforms_cfg.values()
+         ):
+             return transforms_cfg
+     scoped = model_cfg.get("training" if phase == "train" else "inference", {}).get(
+         "transforms"
+     )
+     if isinstance(scoped, dict):
+         return scoped
+     return None
+ 
+ 
+ def build_env_overrides(
+     *,
+     config: dict[str, Any],
+     model_cfg: dict[str, Any],
+     run_paths: RunPaths,
+     training: bool,
+ ) -> dict[str, str]:
+     data_cfg = config.get("data", {})
++    train_cfg = model_cfg.get("training", {})
++    infer_cfg = model_cfg.get("inference", {})
+     overrides: dict[str, str] = {"OUTPUT_DIR": str(run_paths.run_dir)}
+ 
+     seed = config.get("seed")
+     if seed is not None:
+         overrides["SEED"] = str(seed)
+ 
+     device = config.get("device")
+     if device:
+         overrides["DEVICE"] = str(device)
+ 
+     data_root = data_cfg.get("root")
+     if data_root:
+         overrides["DATA_ROOT"] = str(Path(data_root).expanduser().resolve())
+     for key, env_key in (
+         ("train_split", "TRAIN_SPLIT"),
+         ("val_split", "VAL_SPLIT"),
+         ("test_split", "TEST_SPLIT"),
+         ("img_size", "IMG_SIZE"),
+         ("num_classes", "NUM_CLASSES"),
+     ):
+         value = data_cfg.get(key)
+         if value is not None:
+             overrides[env_key] = str(value)
+ 
+-    num_classes = model_cfg.get("num_classes")
++    num_classes = infer_cfg.get(
++        "num_classes",
++        model_cfg.get("num_classes", data_cfg.get("num_classes")),
++    )
+     if num_classes is not None:
+         overrides["NUM_CLASSES"] = str(num_classes)
+ 
+     if training:
+-        train_cfg = model_cfg.get("training", {})
+         if "batch_size" in train_cfg:
+             overrides["BATCH_SIZE"] = str(train_cfg["batch_size"])
+         if "epochs" in train_cfg:
+             overrides["EPOCHS"] = str(train_cfg["epochs"])
+         if "num_workers" in train_cfg:
+             overrides["NUM_WORKERS"] = str(train_cfg["num_workers"])
+         img_override = train_cfg.get("img_size")
+         if img_override is not None:
+             overrides["IMG_SIZE"] = str(img_override)
+         resume_flag = str(train_cfg.get("resume", "")).lower()
+         overrides["RESUME_AUTO"] = (
+             "1" if resume_flag in {"1", "true", "auto"} else "0"
+         )
+     else:
+-        infer_cfg = model_cfg.get("inference", {})
+-        if "batch_size" in infer_cfg:
+-            overrides["BATCH_SIZE"] = str(infer_cfg["batch_size"])
+-        if "num_workers" in infer_cfg:
+-            overrides["NUM_WORKERS"] = str(infer_cfg["num_workers"])
+-        img_override = infer_cfg.get("img_size")
+-        if img_override is not None:
+-            overrides["IMG_SIZE"] = str(img_override)
++        spec = get_model_spec(model_cfg["name"])
++
++        split_override = infer_cfg.get("split")
++        if split_override:
++            overrides["TEST_SPLIT"] = str(split_override)
++
++        batch_size = infer_cfg.get("batch_size")
++        if batch_size is None:
++            batch_size = train_cfg.get("batch_size")
++        if batch_size is None:
++            batch_size = 64
++        overrides["BATCH_SIZE"] = str(batch_size)
++
++        num_workers = infer_cfg.get("num_workers")
++        if num_workers is None:
++            num_workers = train_cfg.get("num_workers")
++        if num_workers is None:
++            num_workers = data_cfg.get("num_workers", 0)
++        overrides["NUM_WORKERS"] = str(num_workers)
++
++        image_size = infer_cfg.get("img_size")
++        if image_size is None:
++            image_size = train_cfg.get("img_size")
++        if image_size is None:
++            image_size = data_cfg.get("img_size", spec.default_image_size)
++        overrides["IMG_SIZE"] = str(image_size)
+ 
+     phase_key = "train" if training else "eval"
+     transform_overrides = resolve_transform_mapping(model_cfg, phase=phase_key)
+     if transform_overrides:
+         overrides["TRANSFORMS"] = json.dumps(transform_overrides)
+ 
+     return overrides
+ 
+ 
+ def import_trainer(module_name: str) -> Any:
+     module = importlib.import_module(module_name)
+     if hasattr(module, "main"):
+         return module.main
+     msg = f"Trainer module '{module_name}' must expose a main() function."
+     raise AttributeError(msg)
+ 
+ 
+ def run_training_job(
+     config: dict[str, Any], model_cfg: dict[str, Any], run_paths: RunPaths
+ ) -> None:
+     spec = get_model_spec(model_cfg["name"])
+     overrides = build_env_overrides(
+         config=config, model_cfg=model_cfg, run_paths=run_paths, training=True
+     )
+     log_path = run_paths.logs / "train.log"
+@@ -496,50 +518,56 @@ def _run_inference_job(
+                         probs = torch.softmax(logits, dim=1)
+                         val_probs_list.append(probs[:, 1].cpu())
+                         val_targets_list.append(targets.cpu())
+                 val_scores = torch.cat(val_probs_list, dim=0).numpy()
+                 val_true = torch.cat(val_targets_list, dim=0).numpy()
+                 if val_scores.size > 0 and val_true.size > 0 and np.unique(val_true).size > 1:
+                     thresholds = np.linspace(0.0, 1.0, 501, dtype=np.float64)
+                     best_bal = -1.0
+                     chosen = 0.5
+                     for thr in thresholds:
+                         preds = (val_scores >= thr).astype(np.int64)
+                         bal = balanced_accuracy_score(val_true, preds)
+                         if bal > best_bal:
+                             best_bal = float(bal)
+                             chosen = float(thr)
+                     best_threshold = float(chosen)
+     # -------------------------------------------------------------------------------
+ 
+     split = split_name
+     dataset_path = data_root / split
+     if not dataset_path.exists():
+         local_console.print(f"[bold red]Split not found:[/] {dataset_path}")
+         raise SystemExit(1)
+ 
+     dataset = datasets.ImageFolder(dataset_path, transform=transforms_eval)
++    require_num_classes(
++        dataset,
++        num_classes,
++        split=split,
++        dataset_root=dataset_path,
++    )
+     if len(dataset) == 0:
+         local_console.print(f"[bold yellow]No images found in[/] {dataset_path}")
+         return
+ 
+     dataloader = build_inference_loader(
+         dataset=dataset, batch_size=batch_size, num_workers=num_workers
+     )
+ 
+     progress = Progress(
+         TextColumn("[bold blue]{task.description}"),
+         BarColumn(bar_width=None),
+         MofNCompleteColumn(),
+         TimeElapsedColumn(),
+         TimeRemainingColumn(),
+         TextColumn("{task.fields[speed]}"),
+         console=local_console,
+     )
+ 
+     all_probs: list[torch.Tensor] = []
+     all_preds: list[torch.Tensor] = []
+     all_targets: list[torch.Tensor] = []
+ 
+     start = perf_counter()
+     images_seen = 0
+     with progress:
+diff --git a/orchestration/train_env.py b/orchestration/train_env.py
+index 7349dba98fd94d5bcd156f60afe9c260a80c4626..3b5cc3a3c5848a817f9ad17015d7d599fa637a4c 100644
+--- a/orchestration/train_env.py
++++ b/orchestration/train_env.py
+@@ -271,63 +271,72 @@ def save_best_checkpoint(env: TrainingEnvironment, state: dict[str, Any]) -> Non
+     torch.save(state, env.best_checkpoint_path)
+     torch.save(state["model"], env.best_weights_path)
+ 
+ 
+ def maybe_load_checkpoint(
+     env: TrainingEnvironment,
+     *,
+     model: torch.nn.Module,
+     optimizer: Optimizer | None = None,
+     scheduler: LRScheduler | None = None,
+ ) -> dict[str, Any] | None:
+     """Load ``latest.ckpt`` when auto-resume is requested."""
+ 
+     if env.resume_checkpoint is None:
+         return None
+ 
+     state = torch.load(env.resume_checkpoint, map_location="cpu")
+     model.load_state_dict(state["model"])
+     if optimizer is not None and state.get("optimizer") is not None:
+         optimizer.load_state_dict(state["optimizer"])
+     if scheduler is not None and state.get("scheduler") is not None:
+         scheduler.load_state_dict(state["scheduler"])
+     return state
+ 
+ 
+-def require_num_classes(dataset: Any, expected: int, *, split: str) -> None:
++def require_num_classes(
++    dataset: Any,
++    expected: int,
++    *,
++    split: str,
++    dataset_root: Path | str | None = None,
++) -> None:
+     """Ensure an ImageFolder-style dataset exposes the configured classes."""
+ 
+     if expected <= 0:
+         raise ValueError("expected number of classes must be positive")
+ 
+     classes: Sequence[Any] | None = getattr(dataset, "classes", None)
+     if classes is None:
+         return
+ 
+     actual = len(classes)
+     if actual == expected:
+         return
+ 
+     preview = ", ".join(str(name) for name in classes[: min(5, actual)])
+     if actual > 5:
+         preview += ", …"
++    root_hint = ""
++    if dataset_root is not None:
++        root_hint = f" at {Path(dataset_root)}"
+     raise ValueError(
+         "Class count mismatch for split "
+-        f"'{split}': dataset exposes {actual} classes ({preview}) "
++        f"'{split}'{root_hint}: dataset exposes {actual} classes ({preview}) "
+         f"but configuration sets NUM_CLASSES={expected}. "
+         "Update config.data.num_classes (e.g., match it to the true number of "
+         "categories in your ImageFolder)."
+     )
+ 
+ 
+ __all__ = [
+     "TrainingEnvironment",
+     "apply_seed",
+     "env_int",
+     "env_path",
+     "env_str",
+     "maybe_load_checkpoint",
+     "prepare_training_environment",
+     "require_num_classes",
+     "save_best_checkpoint",
+     "save_latest_checkpoint",
+ ]
+ 
+EOF
+)

--- a/trainers/efficientformer_v2.py
+++ b/trainers/efficientformer_v2.py
@@ -263,14 +263,14 @@ def main() -> None:  # noqa: PLR0915
     )
     apply_seed(env.seed)
 
-    data_root = env_path("DD_DATA_ROOT", DATA_ROOT)
-    train_split = env_str("DD_TRAIN_SPLIT", "Train")
-    val_split = env_str("DD_VAL_SPLIT", "Validation")
-    batch_size = env_int("DD_BATCH_SIZE", BATCH_SIZE)
-    epochs = env_int("DD_EPOCHS", EPOCHS)
-    img_size = env_int("DD_IMG_SIZE", IMG_SIZE)
-    num_workers = env_int("DD_NUM_WORKERS", NUM_WORKERS)
-    num_classes = env_int("DD_NUM_CLASSES", 2)
+    data_root = env_path("DATA_ROOT", DATA_ROOT)
+    train_split = env_str("TRAIN_SPLIT", "Train")
+    val_split = env_str("VAL_SPLIT", "Validation")
+    batch_size = env_int("BATCH_SIZE", BATCH_SIZE)
+    epochs = env_int("EPOCHS", EPOCHS)
+    img_size = env_int("IMG_SIZE", IMG_SIZE)
+    num_workers = env_int("NUM_WORKERS", NUM_WORKERS)
+    num_classes = env_int("NUM_CLASSES", 2)
 
     use_cuda = torch.cuda.is_available()
     device = "cuda" if use_cuda else "cpu"

--- a/trainers/efficientnet.py
+++ b/trainers/efficientnet.py
@@ -341,14 +341,14 @@ def main() -> None:  # noqa: PLR0915
     )
     apply_seed(env.seed)
 
-    data_root = env_path("DD_DATA_ROOT", DATA_ROOT)
-    train_split = env_str("DD_TRAIN_SPLIT", "Train")
-    val_split = env_str("DD_VAL_SPLIT", "Validation")
-    batch_size = env_int("DD_BATCH_SIZE", BATCH_SIZE)
-    epochs = env_int("DD_EPOCHS", EPOCHS)
-    img_size = env_int("DD_IMG_SIZE", IMG_SIZE)
-    num_workers = env_int("DD_NUM_WORKERS", NUM_WORKERS)
-    num_classes = env_int("DD_NUM_CLASSES", 2)
+    data_root = env_path("DATA_ROOT", DATA_ROOT)
+    train_split = env_str("TRAIN_SPLIT", "Train")
+    val_split = env_str("VAL_SPLIT", "Validation")
+    batch_size = env_int("BATCH_SIZE", BATCH_SIZE)
+    epochs = env_int("EPOCHS", EPOCHS)
+    img_size = env_int("IMG_SIZE", IMG_SIZE)
+    num_workers = env_int("NUM_WORKERS", NUM_WORKERS)
+    num_classes = env_int("NUM_CLASSES", 2)
 
     use_cuda = torch.cuda.is_available()
     device = "cuda" if use_cuda else "cpu"

--- a/trainers/fastervit.py
+++ b/trainers/fastervit.py
@@ -308,14 +308,14 @@ def main() -> None:  # noqa: PLR0915
     )
     apply_seed(env.seed)
 
-    data_root = env_path("DD_DATA_ROOT", DATA_ROOT)
-    train_split = env_str("DD_TRAIN_SPLIT", "Train")
-    val_split = env_str("DD_VAL_SPLIT", "Validation")
-    batch_size = env_int("DD_BATCH_SIZE", BATCH_SIZE)
-    epochs = env_int("DD_EPOCHS", EPOCHS)
-    img_size = env_int("DD_IMG_SIZE", IMG_SIZE)
-    num_workers = env_int("DD_NUM_WORKERS", NUM_WORKERS)
-    num_classes = env_int("DD_NUM_CLASSES", 2)
+    data_root = env_path("DATA_ROOT", DATA_ROOT)
+    train_split = env_str("TRAIN_SPLIT", "Train")
+    val_split = env_str("VAL_SPLIT", "Validation")
+    batch_size = env_int("BATCH_SIZE", BATCH_SIZE)
+    epochs = env_int("EPOCHS", EPOCHS)
+    img_size = env_int("IMG_SIZE", IMG_SIZE)
+    num_workers = env_int("NUM_WORKERS", NUM_WORKERS)
+    num_classes = env_int("NUM_CLASSES", 2)
 
     use_cuda = torch.cuda.is_available()
     device = "cuda" if use_cuda else "cpu"


### PR DESCRIPTION
This MR tightens the inference path so that environment overrides are taken from the model’s inference block (with sensible fallbacks from data) instead of implicitly mirroring training-only values. It also adds a dataset class-count check to inference, reusing the shared helper so runs fail fast when the `ImageFolder` layout doesn’t match the configured `num_classes`. Closes #27 and #28.